### PR TITLE
Fix broken links to CONTRIBUTING and Code of Conduct in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here’s a quick breakdown of the core files that power this website:
 - 🌐 CNAME → Used for custom domain setup on GitHub Pages.
 - 📜 LICENSE.md → Open-source MIT License.
 - 🤌 CONTRIBUTING.md → Reflecting steps for open source contributionss.
-- 📈 CODE_OF_CONDUCT.md → Guided by values of respect, collaboration & clarity — see [Code of Conduct](https://github.com/ayushHardeniya/ayushhardeniya.github.io/blob/main/CODE_OF_CONDUCT.md)
+- 📈 CODE_OF_CONDUCT.md → Guided by values of respect, collaboration & clarity — see [Code of Conduct](https://github.com/ayushHardeniya/ayushhardeniya.github.io/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ---
 
@@ -58,7 +58,7 @@ Since this is a static website, simply open the index.html file in your browser:
 ### 🤝 Want to Contribute? Here’s How!
 This website is open-source, and your improvements matter! Whether it's UI enhancements, bug fixes, or new features, every contribution helps. <br>
 📜 Contribution Guidelines<br>
-To keep contributions organized, please read our [CONTRIBUTING.md](https://github.com/ayushHardeniya/ayushhardeniya.github.io/blob/main/CONTRIBUTING.md) file before submitting any changes. It covers: <br>
+To keep contributions organized, please read our [CONTRIBUTING.md](https://github.com/ayushHardeniya/ayushhardeniya.github.io/blob/main/.github/CONTRIBUTING.md) file before submitting any changes. It covers: <br>
 ✅ How to fork & clone the repository.<br>
 ✅ How to create branches and follow best practices.<br>
 ✅ How to submit pull requests properly.


### PR DESCRIPTION
Corrected the links to CONTRIBUTING.md and CODE_OF_CONDUCT.md in README.md by adding the missing `/.github/` path. 

Changes in > Line - 61 and Line - 23

Previously:
- [CONTRIBUTING.md](CONTRIBUTING.md) → ❌ 404
- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) → ❌ 404

Now:
- [CONTRIBUTING.md](.github/CONTRIBUTING.md) → ✅ Working
- [CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md) → ✅ Working

These files are stored in the `.github` directory, and the updated relative paths now properly resolve.

Fixes broken navigation in the README and improves the contributor onboarding experience.


👤 **Contributor Name:**  
  @avinash-394
